### PR TITLE
mod: RecordContainer 오버플로우 문제 수정

### DIFF
--- a/lib/components/my_page/record_container.dart
+++ b/lib/components/my_page/record_container.dart
@@ -9,7 +9,6 @@ class RecordContainer extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       width: double.infinity,
-      height: 116.h,
       decoration: BoxDecoration(
         color: Palette.container,
         borderRadius: BorderRadius.circular(20.r),
@@ -17,61 +16,66 @@ class RecordContainer extends StatelessWidget {
       padding: EdgeInsets.symmetric(horizontal: 20.w, vertical: 20.h),
       child: Row(
         children: [
-          Container(
-            padding: EdgeInsets.symmetric(horizontal: 18.w),
+          Expanded(
             child: Column(
               children: [
                 Text(
-                  "지금까지 산책한 거리",
+                  '지금까지 산책한 거리',
                   style: Palette.caption.copyWith(
                     color: Palette.onSurfaceVariant,
                   ),
                 ),
                 SizedBox(height: 24.h),
+
                 Text.rich(
                   TextSpan(
                     children: [
                       TextSpan(
-                        text: "24",
+                        text: '24',
                         style: Palette.largeTitle.copyWith(
                           color: Palette.primary,
                         ),
                       ),
-                      TextSpan(text: "km", style: Palette.body),
+                      TextSpan(text: 'km', style: Palette.body),
                     ],
                   ),
                 ),
               ],
             ),
           ),
-          SizedBox(width: 18.w),
-          VerticalDivider(
-            width: 0,
-            thickness: 1,
-            color: Palette.surfaceVariant,
-          ),
-          SizedBox(width: 18.w),
+
+          SizedBox(width: 20.w),
           Container(
-            padding: EdgeInsets.symmetric(horizontal: 18.w),
+            width: 1,
+            height: 70.h,
+            decoration: BoxDecoration(
+              color: Palette.surfaceVariant,
+              borderRadius: BorderRadius.circular(1.r),
+            ),
+          ),
+          SizedBox(width: 20.w),
+
+          Expanded(
             child: Column(
               children: [
                 Text(
-                  "지금까지 산책한 시간",
+                  '지금까지 산책한 시간',
                   style: Palette.caption.copyWith(
                     color: Palette.onSurfaceVariant,
                   ),
                 ),
                 SizedBox(height: 24.h),
+
                 Text.rich(
                   TextSpan(
                     children: [
                       TextSpan(
-                        text: "452",
+                        text: '452',
                         style: Palette.largeTitle.copyWith(
                           color: Palette.primary,
                         ),
                       ),
-                      TextSpan(text: "분", style: Palette.body),
+                      TextSpan(text: '분', style: Palette.body),
                     ],
                   ),
                 ),


### PR DESCRIPTION
## 📝작업 내용
`RecordContainer`에서 오버플로우 추정되는 원인을 제거하고 원래 크기대로 되돌렸습니다.
- 각 컨테이너에서 패딩을 제거하고 `Expanded`로 감싸도록 수정했습니다.
- 전체 컨테이너의 height를 제거했습니다.