### PR TITLE
feat: ui 수정

### DIFF
--- a/lib/components/walk/walk_end_dialog.dart
+++ b/lib/components/walk/walk_end_dialog.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:yeogijeogi/components/common/custom_button.dart';
-import 'package:yeogijeogi/components/common/custom_text_button.dart';
 import 'package:yeogijeogi/utils/palette.dart';
 
 Future<void> showWalkEndDialog({
@@ -33,10 +32,6 @@ Future<void> showWalkEndDialog({
 
                 // 저장 버튼
                 CustomButton(text: '산책 코스 저장하기', onTap: onTapSave),
-                SizedBox(height: 20.h),
-
-                // 저장 안하기 버튼
-                CustomTextButton(text: '저장하지 않고 종료하기', onTap: onTapCancel),
               ],
             ),
           ),

--- a/lib/views/walk/save_view.dart
+++ b/lib/views/walk/save_view.dart
@@ -3,7 +3,6 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
 import 'package:yeogijeogi/components/common/custom_button.dart';
 import 'package:yeogijeogi/components/common/custom_scaffold.dart';
-import 'package:yeogijeogi/components/common/custom_text_button.dart';
 import 'package:yeogijeogi/components/walk/course_detail.dart';
 import 'package:yeogijeogi/components/walk/memo_text_field.dart';
 import 'package:yeogijeogi/components/walk/slider_container.dart';
@@ -66,14 +65,6 @@ class SaveView extends StatelessWidget {
 
             MemoTextField(controller: saveViewModel.controller),
             SizedBox(height: 40.h),
-
-            Center(
-              child: CustomTextButton(
-                text: '저장하지 않고 종료하기',
-                onTap: saveViewModel.onTapNotSave,
-              ),
-            ),
-            SizedBox(height: 20.h),
 
             CustomButton(text: '산책 코스 저장하기', onTap: () {}),
           ],


### PR DESCRIPTION
## 📝작업 내용
수정된 디자인 적용했습니다. 
- 산책 종료 팝업에서 '저장하지 않고 종료하기' 텍스트 버튼 제거
- 산책 저장 페이지에서 '저장하지 않고 종료하기' 텍스트 버튼 제거 

## 스크린샷
<img width="20%" alt="스크린샷 2025-04-04 오후 8 06 04" src="https://github.com/user-attachments/assets/6a546a37-f1b3-472d-827d-8dd8db743a8b" />
<img width="20%" alt="스크린샷 2025-04-04 오후 8 06 59" src="https://github.com/user-attachments/assets/5cf04715-279c-48af-8412-8c29d3680242" />

## 💬리뷰 요구사항
산책 상세 보기 페이지는 충돌 날 것 같아서 아직 작업 안했습니다.