### PR TITLE
fix: 코스 화면 모달 완전히 열리지 않는 문제 해결

### DIFF
--- a/lib/components/course/modal_course_detail.dart
+++ b/lib/components/course/modal_course_detail.dart
@@ -41,7 +41,6 @@ class ModalCourseDetail extends StatelessWidget {
       primary: false,
       padding: EdgeInsets.zero,
       controller: scrollController,
-      physics: isExpanded ? null : ClampingScrollPhysics(),
       children: [
         // 핸들
         if (!isExpanded)

--- a/lib/components/walk/course_detail.dart
+++ b/lib/components/walk/course_detail.dart
@@ -90,7 +90,10 @@ class CourseDetail extends StatelessWidget {
               Expanded(
                 child: Column(
                   children: [
-                    Text('${distance}km', style: Palette.callout),
+                    Text(
+                      '${distance % 1 == 0 ? distance.toStringAsFixed(0) : distance.toStringAsFixed(2)}km',
+                      style: Palette.callout,
+                    ),
                     SizedBox(height: 8.h),
 
                     Text(

--- a/lib/view_models/course/course_view_model.dart
+++ b/lib/view_models/course/course_view_model.dart
@@ -15,6 +15,9 @@ class CourseViewModel with ChangeNotifier {
   final BuildContext context;
 
   CourseViewModel({required this.courseModel, required this.context}) {
+    isLoading = true;
+    notifyListeners();
+
     // 모달 드래그 리스너 추가
     draggableController.addListener(_onDrag);
   }
@@ -77,6 +80,9 @@ class CourseViewModel with ChangeNotifier {
         onTapMarker(marker);
       }
     }
+
+    isLoading = false;
+    notifyListeners();
   }
 
   // 마커 탭 리스너
@@ -104,7 +110,11 @@ class CourseViewModel with ChangeNotifier {
 
   /// 앱바 뒤로가기 버튼
   void onTapBack() {
-    draggableController.reset();
+    draggableController.animateTo(
+      0.228,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeInOut,
+    );
   }
 
   /// 모달 열렸을 때 상세 정보 가져오기


### PR DESCRIPTION
## 📝작업 내용
코스 지도 로딩 중 로딩 표시 뜨도록 했습니다.
`CourseDetail` 컴포넌트에서 소수점 2자리까지 표시하도록 수정했습니다.
코스 모달이 완전히 열리지 않던 문제를 해결했습니다. 
- `ListView`에서 `physics`를 설정한 것이 문제였어서 제거했습니다.