### PR TITLE
feat: walk/end GET, POST 적용

### DIFF
--- a/lib/components/walk/walk_end_dialog.dart
+++ b/lib/components/walk/walk_end_dialog.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:yeogijeogi/components/common/custom_button.dart';
+import 'package:yeogijeogi/models/objects/walk_summary.dart';
 import 'package:yeogijeogi/utils/palette.dart';
 
 Future<void> showWalkEndDialog({
   required BuildContext context,
+  required WalkSummary summary,
   required Function() onTapSave,
   required Function() onTapCancel,
 }) async {
@@ -24,7 +26,7 @@ Future<void> showWalkEndDialog({
 
                 // 산책 요약
                 Text(
-                  '안암역 - 성북천\n이동 거리 : 1.3km\n평균 속도 : 3km/h\n소요 시간 : 24분',
+                  '${summary.startName} - ${summary.endName}\n이동 거리 : ${summary.distance}km\n평균 속도 : ${summary.speed}km/h\n소요 시간 : ${summary.time}분',
                   textAlign: TextAlign.center,
                   style: Palette.body.copyWith(color: Palette.onSurfaceVariant),
                 ),

--- a/lib/models/objects/walk_summary.dart
+++ b/lib/models/objects/walk_summary.dart
@@ -1,0 +1,27 @@
+import 'package:yeogijeogi/utils/utils.dart';
+
+class WalkSummary {
+  final String startName;
+  final String endName;
+  final double distance;
+  final double speed;
+  final int time;
+
+  WalkSummary({
+    required this.startName,
+    required this.endName,
+    required this.distance,
+    required this.speed,
+    required this.time,
+  });
+
+  factory WalkSummary.fromJson(Map<String, dynamic> json) {
+    return WalkSummary(
+      startName: json['start_name'],
+      endName: json['end_name'],
+      distance: toFixedDigits(json['distance']),
+      speed: calAvgSpeed(json['distance'], json['time']),
+      time: json['time'],
+    );
+  }
+}

--- a/lib/models/walk_model.dart
+++ b/lib/models/walk_model.dart
@@ -5,6 +5,7 @@ import 'package:flutter_naver_map/flutter_naver_map.dart';
 import 'package:yeogijeogi/models/objects/coordinate.dart';
 import 'package:yeogijeogi/models/objects/recommendation.dart';
 import 'package:yeogijeogi/models/objects/walk_point.dart';
+import 'package:yeogijeogi/models/objects/walk_summary.dart';
 import 'package:yeogijeogi/utils/api.dart';
 
 class WalkModel with ChangeNotifier {
@@ -16,6 +17,9 @@ class WalkModel with ChangeNotifier {
 
   /// 도착 주소
   String? endName;
+
+  /// 도착 주소
+  String? endAddress;
 
   /// 시간
   int? time;
@@ -51,11 +55,15 @@ class WalkModel with ChangeNotifier {
   /// 추천 목적지 리스트
   List<Recommendation> recommendationList = [];
 
+  /// 지금까지 산책한 내용 요약 정보
+  WalkSummary? summary;
+
   /// 모델 초기화
   void reset() {
     id = null;
     startName = null;
     endName = null;
+    endAddress = null;
     time = null;
     averageSpeed = null;
     distance = null;
@@ -68,6 +76,7 @@ class WalkModel with ChangeNotifier {
     pathList.clear();
     image?.delete();
     image = null;
+    summary = null;
 
     debugPrint('Reset WalkModel');
   }
@@ -98,6 +107,7 @@ class WalkModel with ChangeNotifier {
 
     routes = recommendationList[index].routes;
     endName = recommendationList[index].name;
+    endAddress = recommendationList[index].address;
     distance = recommendationList[index].distance;
     time = recommendationList[index].time;
     recommendationList.clear();

--- a/lib/utils/api.dart
+++ b/lib/utils/api.dart
@@ -7,6 +7,7 @@ import 'package:yeogijeogi/models/objects/coordinate.dart';
 import 'package:yeogijeogi/models/objects/course.dart';
 import 'package:yeogijeogi/models/objects/recommendation.dart';
 import 'package:yeogijeogi/models/objects/walk_point.dart';
+import 'package:yeogijeogi/models/objects/walk_summary.dart';
 import 'package:yeogijeogi/utils/custom_interceptor.dart';
 
 class API {
@@ -146,19 +147,43 @@ class API {
     }
   }
 
-  /// 산책 종료
-  static Future<Map<String, dynamic>> postWalkEnd(String walkId) async {
+  /// 산책 요약 불러오기
+  static Future<WalkSummary> getWalkEnd(String walkId) async {
     try {
-      final response = await _postApi(
+      final response = await _getApi(
         '/walk/end',
-        jsonData: {'walk_id': walkId},
+        queryParameters: {'walk_id': walkId},
       );
 
       if (response != null) {
-        return response.data;
+        return WalkSummary.fromJson(response.data);
       } else {
         throw Error();
       }
+    } catch (e) {
+      debugPrint('Error in getWalkEnd: $e');
+      throw Error();
+    }
+  }
+
+  /// 산책 종료
+  static Future<void> postWalkEnd(
+    String walkId,
+    WalkSummary summary,
+    String endAddress,
+  ) async {
+    try {
+      await _postApi(
+        '/walk/end',
+        jsonData: {
+          'walk_id': walkId,
+          'start_name': summary.startName,
+          'end_name': summary.endName,
+          'end_address': endAddress,
+          'distance': summary.distance,
+          'time': summary.time,
+        },
+      );
     } catch (e) {
       debugPrint('Error in postWalkEnd: $e');
       throw Error();

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -1,8 +1,13 @@
 /// 평균 속도 계산
 double calAvgSpeed(double? distance, int? time) {
   if (time != null && time != 0 && distance != null) {
-    return distance / time;
+    return toFixedDigits(distance / time);
   } else {
     return 0;
   }
+}
+
+/// 소수점 자리를 지정해서 반환하는 함수
+double toFixedDigits(double value, {int digit = 2}) {
+  return double.parse(value.toStringAsFixed(digit));
 }

--- a/lib/view_models/walk/save_view_model.dart
+++ b/lib/view_models/walk/save_view_model.dart
@@ -7,7 +7,6 @@ import 'package:yeogijeogi/models/objects/course.dart';
 import 'package:yeogijeogi/models/walk_model.dart';
 import 'package:yeogijeogi/utils/api.dart';
 import 'package:yeogijeogi/utils/enums/app_routes.dart';
-import 'package:yeogijeogi/utils/utils.dart';
 
 class SaveViewModel with ChangeNotifier {
   CourseModel courseModel;
@@ -103,9 +102,9 @@ class SaveViewModel with ChangeNotifier {
         location: Coordinate.fromNLatLng(walkModel.pathList.last),
         name: walkModel.endName!,
         address: walkModel.endName!,
-        distance: walkModel.distance!,
-        time: walkModel.time!,
-        speed: calAvgSpeed(walkModel.distance!, walkModel.time!),
+        distance: walkModel.summary!.distance,
+        time: walkModel.summary!.time,
+        speed: walkModel.summary!.speed,
         imgUrl: imageUrl,
         mood: moodLevel.toDouble(),
         difficulty: difficultyLevel.toDouble(),

--- a/lib/views/walk/save_view.dart
+++ b/lib/views/walk/save_view.dart
@@ -44,13 +44,13 @@ class SaveView extends StatelessWidget {
             SizedBox(height: 24.h),
 
             CourseDetail(
-              name: '성북천',
-              address: '서울 성북구 동선동2가',
-              distance: 1.3,
+              name: saveViewModel.walkModel.summary!.endName,
+              address: saveViewModel.walkModel.endAddress!,
+              distance: saveViewModel.walkModel.summary!.distance,
               distanceLabel: '이동 거리',
-              walk: '3km/h',
+              walk: '${saveViewModel.walkModel.summary!.speed}km/h',
               walkLabel: '평균 속도',
-              time: 24,
+              time: saveViewModel.walkModel.summary!.time,
               timeLabel: '소요 시간',
             ),
             SizedBox(height: 24.h),


### PR DESCRIPTION
## 📝작업 내용
산책 종료 시점에서 walk/end GET, POST api 수정 및 적용했습니다.
- 산책 정보인 `WalkSummary` 오브젝트를 만들었습니다. 
- `SaveView`에서 산책 요약 정보를 불러옵니다.

## 스크린샷
<img src="https://github.com/user-attachments/assets/5c2da34a-b174-49b7-8146-a3c694e40327" width="20%" />
<img src="https://github.com/user-attachments/assets/186ffaec-44e9-461f-a09d-723fc18aed38" width="20%" />

