### PR TITLE
feat: 로그인시 getCourse 실행, 로그아웃/회원탈퇴시 모델 재설정

### DIFF
--- a/lib/utils/app_router.dart
+++ b/lib/utils/app_router.dart
@@ -55,8 +55,11 @@ class AppRouter {
           builder:
               (context, _) => ChangeNotifierProvider(
                 create:
-                    (context) =>
-                        LoginViewModel(userModel: userModel, context: context),
+                    (context) => LoginViewModel(
+                      userModel: userModel,
+                      courseModel: courseModel,
+                      context: context,
+                    ),
                 child: const LoginView(),
               ),
         ),
@@ -174,6 +177,8 @@ class AppRouter {
                         create:
                             (context) => MyPageViewModel(
                               userModel: userModel,
+                              courseModel: courseModel,
+                              walkModel: walkModel,
                               context: context,
                             ),
                         child: const MyPageView(),

--- a/lib/view_models/login_view_model.dart
+++ b/lib/view_models/login_view_model.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'package:yeogijeogi/components/common/error_dialog.dart';
+import 'package:yeogijeogi/models/course_model.dart';
 import 'package:yeogijeogi/models/user_model.dart';
 import 'package:yeogijeogi/utils/api.dart';
 import 'package:yeogijeogi/utils/constants.dart';
@@ -14,9 +15,14 @@ import 'package:yeogijeogi/utils/enums/app_routes.dart';
 
 class LoginViewModel with ChangeNotifier {
   UserModel userModel;
+  CourseModel courseModel;
   BuildContext context;
 
-  LoginViewModel({required this.userModel, required this.context});
+  LoginViewModel({
+    required this.userModel,
+    required this.courseModel,
+    required this.context,
+  });
 
   /// Firebase
   final FirebaseAuth _firebaseAuth = FirebaseAuth.instance;
@@ -60,6 +66,9 @@ class LoginViewModel with ChangeNotifier {
 
           final userInfo = await API.getUserInfo();
           userModel.fromJson(userInfo);
+
+          // Course 정보 불러오기
+          courseModel.getCourses();
 
           isLoading = false;
           notifyListeners();
@@ -129,7 +138,7 @@ class LoginViewModel with ChangeNotifier {
       try {
         if (userCredential.additionalUserInfo!.isNewUser) {
           await API.postCreateUser();
-          
+
           final int rand = Random().nextInt(randomNicknames.length);
           final String randomNickname = randomNicknames[rand];
           await user?.updateDisplayName(randomNickname);
@@ -141,6 +150,9 @@ class LoginViewModel with ChangeNotifier {
 
           final userInfo = await API.getUserInfo();
           userModel.fromJson(userInfo);
+
+          // Course 정보 불러오기
+          courseModel.getCourses();
 
           isLoading = false;
           notifyListeners();

--- a/lib/view_models/my_page_view_model.dart
+++ b/lib/view_models/my_page_view_model.dart
@@ -6,7 +6,9 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:yeogijeogi/components/common/custom_dialog.dart';
 import 'package:yeogijeogi/components/common/error_dialog.dart';
 import 'package:yeogijeogi/components/my_page/nickname_dialog.dart';
+import 'package:yeogijeogi/models/course_model.dart';
 import 'package:yeogijeogi/models/user_model.dart';
+import 'package:yeogijeogi/models/walk_model.dart';
 import 'package:yeogijeogi/utils/api.dart';
 import 'package:yeogijeogi/utils/custom_exception.dart';
 import 'package:yeogijeogi/utils/enums/app_routes.dart';
@@ -14,9 +16,16 @@ import 'package:yeogijeogi/utils/enums/dialog_type.dart';
 
 class MyPageViewModel with ChangeNotifier {
   UserModel userModel;
+  CourseModel courseModel;
+  WalkModel walkModel;
   BuildContext context;
 
-  MyPageViewModel({required this.userModel, required this.context}) {
+  MyPageViewModel({
+    required this.userModel,
+    required this.courseModel,
+    required this.walkModel,
+    required this.context,
+  }) {
     getAppVersion();
   }
 
@@ -73,13 +82,21 @@ class MyPageViewModel with ChangeNotifier {
       context: context,
       onTapAction: () async {
         try {
+          isLoading = true;
+          notifyListeners();
+
+          context.pop();
+
           await API.deleteUser();
           await FirebaseAuth.instance.signOut();
 
           if (context.mounted) {
+            // 모델 초기화
             userModel.reset();
+            courseModel.reset();
+            walkModel.reset();
+
             context.goNamed(AppRoute.login.name);
-            context.pop();
           }
         } catch (e) {
           if (context.mounted) {
@@ -89,6 +106,9 @@ class MyPageViewModel with ChangeNotifier {
             );
           }
         }
+
+        isLoading = false;
+        notifyListeners();
       },
     );
   }
@@ -99,13 +119,26 @@ class MyPageViewModel with ChangeNotifier {
       type: DialogType.logout,
       context: context,
       onTapAction: () async {
-        /// 로그아웃 후 login 페이지로 이동
+        isLoading = true;
+        notifyListeners();
+
+        context.pop();
+
+        // 로그아웃 후 login 페이지로 이동
         await FirebaseAuth.instance.signOut();
+
+        // 모델 초기화
+        userModel.reset();
+        courseModel.reset();
+        walkModel.reset();
+
         if (context.mounted) {
           userModel.reset();
           context.goNamed(AppRoute.login.name);
-          context.pop();
         }
+
+        isLoading = false;
+        notifyListeners();
       },
     );
   }


### PR DESCRIPTION
## 📝작업 내용
로그인시 getCourse를 실행하도록 수정했습니다. 

로그아웃/회원탈퇴 시 모든 모델을 reset 하도록 수정했습니다. 

이제 더이상 계정을 바꾸거나 할 때 데이터가 제대로 로딩되지 않는 오류가 나지 않습니다. (아마도?)
